### PR TITLE
feat: Allow dropbox files to be accessed publically.

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -1,0 +1,33 @@
+<?php
+
+$dropboxDisks = array_where(config('cms.storage'), function ($disk) {
+    return $disk['disk'] === 'dropbox';
+});
+
+/**
+ * Registers routes for each dropbox disk proxying thro' the dropbox share link API.
+ */
+foreach ($dropboxDisks as $dropboxDisk) {
+    $diskFolder = $dropboxDisk['folder'];
+    if (!empty($diskFolder)) {
+        Route::get('storage/' . $diskFolder . '/{path}', function ($path) use ($diskFolder) {
+            $params = [
+                'path'      => '/' . $diskFolder . '/' . $path,
+                'short_url' => false
+            ];
+            $headers = [
+                'Authorization' => 'Bearer ' . config('filesystems.disks.dropbox.authorizationToken'),
+                'Content-Type'  => 'application/json'
+            ];
+            $out = Http::post('https://api.dropboxapi.com/2/sharing/create_shared_link', function ($http) use ($headers, $params) {
+                $http->header($headers);
+                $http->setOption(CURLOPT_POSTFIELDS, json_encode($params));
+            });
+            $response = json_decode($out, true);
+            if ($out->code !== 200) {
+                return Redirect::to('404');
+            }
+            return Redirect::to(explode('?', $response['url'])[0] . '?raw=1');
+        })->where('path', '.*');
+    }
+}


### PR DESCRIPTION
Register proxy routes for each dropbox disk so that the file request is served using dropbox's public API. Requires authorization tokens to be registered with sharing.write permission.

Working sample 'cms' config:
```
'storage' => [

    'uploads' => [
        'disk'   => 'dropbox',
        'folder' => 'app/uploads'
    ],

    'media' => [
        'disk'   => 'dropbox',
        'folder' => 'app/media',
        'path'   => url('/storage/app/media')
    ],

],
```

The path parameter doesn't need to be specified in the uploads config block because, by default, OctoberCMS takes uploads paths thro' /storage URL path.

Closes #3.